### PR TITLE
Suppress errors in destroying models

### DIFF
--- a/restclients_core/models/__init__.py
+++ b/restclients_core/models/__init__.py
@@ -80,7 +80,10 @@ class Model(object):
         # This makes sure those values are removed when this object
         # is destroyed.
         for field in self._dynamic_fields:
-            field.__delete__(self)
+            try:
+                field.__delete__(self)
+            except Exception:
+                pass
 
     def clean_fields(self):
         for field in self._dynamic_fields:

--- a/restclients_core/models/fields.py
+++ b/restclients_core/models/fields.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 
 
 class BaseField(object):
@@ -40,7 +41,11 @@ class BaseField(object):
             del self.values[key]
 
     def _key_for_instance(self, instance):
-        return id(instance)
+        if not hasattr(instance, "__rcm_timestamp"):
+            setattr(instance, "__rcm_timestamp", time.time())
+
+        key = "%s-%s" % (id(instance), getattr(instance, "__rcm_timestamp"))
+        return key
 
     def clean(self, instance):
         pass


### PR DESCRIPTION
Also makes it so the data lookup key includes a timestamp.  Timestamp + object id will be unique over time, unlike just object id