### PR TITLE
Fix the bug in mock.load_resource_from_path where a valid handler fro…

### DIFF
--- a/restclients_core/cache_manager.py
+++ b/restclients_core/cache_manager.py
@@ -3,7 +3,9 @@ This is a class that makes it possible to bulk-save cache entries.
 For restclients methods that use threading, this can be used to prevent
 innodb gap locks from deadlocking sequential inserts.
 """
+from logging import getLogger
 
+logger = getLogger(__name__)
 __manage_bulk_inserts = False
 __bulk_insert_queue = []
 
@@ -31,7 +33,7 @@ def save_all_queued_entries():
                 entry.save()
                 seen_urls[entry.url] = True
     except Exception as ex:
-        print("Error bulk saving cache entries: ", ex)
+        logger.error("Error bulk saving cache entries: ", str(ex))
 
     __bulk_insert_queue = []
 

--- a/restclients_core/dao.py
+++ b/restclients_core/dao.py
@@ -399,16 +399,10 @@ class MockDAO(DAOImplementation):
             return value
 
         for path in self._get_mock_paths():
-            response = load_resource_from_path(path, service, "file", url,
-                                               headers)
-
-            if response:
-                set_cache_value(cache_key, response)
-                return response
-
-        response = MockHTTP()
-        response.status = 404
-        response.reason = "Not Found"
+            response = load_resource_from_path(
+                path, service, "file", url, headers)
 
         set_cache_value(cache_key, response)
+        if response.status == 404:
+            response.reason = "Not Found"
         return response

--- a/restclients_core/tests/dao_implementation/resources/testing/file/search_fourth_d_third_c_second_b_first_a.http-headers
+++ b/restclients_core/tests/dao_implementation/resources/testing/file/search_fourth_d_third_c_second_b_first_a.http-headers
@@ -1,0 +1,3 @@
+{ "headers": {"Custom": "My Custom Value"},
+  "status": 200
+}

--- a/restclients_core/tests/dao_implementation/test_mock.py
+++ b/restclients_core/tests/dao_implementation/test_mock.py
@@ -10,6 +10,7 @@ class TDAO(DAO):
         return 'testing'
 
     def service_mock_paths(self):
+        # tests/dao_implementation/resources/
         return [abspath(dirname(__file__) + "/resources/")]
 
 
@@ -46,7 +47,7 @@ class TestMock(TestCase):
 
         response = TDAO().getURL('/override.json', {})
         self.assertEquals(response.status, 200)
-        self.assertEquals(response.read(), b'{"override": true }\n')
+        self.assertEquals(response.read(), b'{"override": false }\n')
 
     def test_binary_data(self):
         response = TDAO().getURL('/image.jpg', {})


### PR DESCRIPTION
Fix the bug in mock.load_resource_from_path function where a valid handler returned from open_file call is overwritten by a None handler returned from attempt_open_query_permutations call.
This bug caused failures of bridge-restclient unit test.